### PR TITLE
define-grammar and define-rule...

### DIFF
--- a/json-parse.lisp
+++ b/json-parse.lisp
@@ -1,155 +1,156 @@
 (defpackage :cl-bnf-json-example
   (:use #:cl #:cl-bnf)
-  (:export #:run))
+  (:export #:run)
+  (:import-from #:cl-bnf
+                #:define-rule
+                #:define-grammar))
 (in-package :cl-bnf-json-example)
 
 (defun stringify (vs)
   (if vs
-    (case (type-of vs)
-     (standard-char (string vs))
-     (t (reduce (lambda (acc x)
-                  (concatenate 'string acc
-                               (if x
-                                   (case (type-of x)
-                                     (standard-char (string x))
-                                     (list (stringify x))
-                                     (cons (stringify x)))
-                                   "")))
-                vs :initial-value ""))) ""))
+      (case (type-of vs)
+        (standard-char (string vs))
+        (t (reduce (lambda (acc x)
+                     (concatenate 'string acc
+                                  (if x
+                                      (case (type-of x)
+                                        (standard-char (string x))
+                                        (list (stringify x))
+                                        (cons (stringify x)))
+                                      "")))
+                   vs :initial-value "")))
+      ""))
 
 (defun numeric-char-p (char)
   (and (char-not-lessp char #\0)
        (char-not-greaterp char #\9)))
 
-(:= spaces (:many (:or (:char #\Space)
-                       (:and (:char #\\)
-                             (:or (:char #\n)
-                                  (:char #\t)))
-                       (:char #\Newline)
-                       (:char #\Tab)))
-    :call #'stringify)
+(define-rule spaces (:many (:or (:char #\Space)
+                                (:and (:char #\\)
+                                      (:or (:char #\n)
+                                           (:char #\t)))
+                                (:char #\Newline)
+                                (:char #\Tab)))
+             :call #'stringify)
 
 ;; number
 
-(:= decimal-number (:many (:one #'numeric-char-p)))
-(:= real-number (:or (:and #'decimal-number
-                           (:char #\.)
-                           #'decimal-number)
-                     (:and #'decimal-number
-                           (:char #\.))))
-(:= signed-part (:or (:char #\+) (:char #\-)))
-(:= exp-chars (:or (:char #\e)
-                   (:char #\E)))
-(:= exp-part (:or (:and #'exp-chars
-                        #'signed-part
-                        #'decimal-number)
-                  (:and #'exp-chars
-                        #'decimal-number)))
-(:= numeric (:or #'real-number
-                 #'decimal-number))
-(:= number-literal (:or (:and #'numeric
-                              #'exp-part)
-                        #'numeric)
-    :call (lambda (matches)
-            (cons :number (stringify matches))))
+(define-rule decimal-number (:many (:one #'numeric-char-p)))
+(define-rule real-number (:or (:and #'decimal-number
+                                    (:char #\.)
+                                    #'decimal-number)
+                              (:and #'decimal-number
+                                    (:char #\.))))
+(define-rule signed-part (:or (:char #\+) (:char #\-)))
+(define-rule exp-chars (:or (:char #\e)
+                            (:char #\E)))
+(define-rule exp-part (:or (:and #'exp-chars
+                                 #'signed-part
+                                 #'decimal-number)
+                           (:and #'exp-chars
+                                 #'decimal-number)))
+(define-rule numeric (:or #'real-number
+                          #'decimal-number))
+(define-rule number-literal (:or (:and #'numeric
+                                       #'exp-part)
+                                 #'numeric)
+             :call (lambda (matches)
+                     (cons :number (stringify matches))))
 
 ;; string
 
-(:= escaped-char (:and (:char #\\)
-                       (:or (:char #\n)
-                            (:char #\t)
-                            (:char #\r)
-                            (:char #\b)
-                            (:char #\\)
-                            (:char #\/))))
-(:= string-literal (:and (:char #\")
-                         (:many (:or #'escaped-char
-                                     (:one #'alpha-char-p)))
-                         (:char #\"))
-     :apply (lambda (a str b)
-              (declare (ignore a b))
-              (cons :string (stringify str))))
+(define-rule escaped-char (:and (:char #\\)
+                                (:or (:char #\n)
+                                     (:char #\t)
+                                     (:char #\r)
+                                     (:char #\b)
+                                     (:char #\\)
+                                     (:char #\/))))
+(define-rule string-literal (:and (:char #\")
+                                  (:many (:or #'escaped-char
+                                              (:one #'alpha-char-p)))
+                                  (:char #\"))
+             :apply (lambda (a str b)
+                      (declare (ignore a b))
+                      (cons :string (stringify str))))
 
 ;; object
 
-(:= key-value (:and #'string-literal
-                    (:maybe #'spaces)
-                    (:char #\:)
-                    (:maybe #'spaces)
-                    #'literals)
-    :apply (lambda (key s c ss value)
-             (declare (ignore c s ss))
-             (cons key value)))
-(:= key-value-continuation (:and #'key-value
-                                 (:char #\,)
-                                 (:maybe #'spaces))
-    :apply (lambda (kv c s)
-             (declare (ignore c s))
-             kv))
-(:= key-value-pairs (:or #'key-value-continuation
-                         #'key-value))
-(:= filled-object (:and (:char #\{)
-                        (:many #'key-value-pairs)
-                        (:char #\}))
-    :apply (lambda (a kvs b)
-             (declare (ignore a b))
-             `(:object ,kvs)))
-(:= empty-object (:and (:char #\{)
-                       (:maybe #'spaces)
-                       (:char #\}))
-    :apply (lambda (a b c)
-             (declare (ignore a b c))
-             `(:object)))
-(:= object-literal (:or #'empty-object
-                        #'filled-object))
+(define-rule key-value (:and #'string-literal
+                             (:maybe #'spaces)
+                             (:char #\:)
+                             (:maybe #'spaces)
+                             #'literals)
+             :apply (lambda (key s c ss value)
+                      (declare (ignore c s ss))
+                      (cons key value)))
+(define-rule key-value-continuation (:and #'key-value
+                                          (:char #\,)
+                                          (:maybe #'spaces))
+             :apply (lambda (kv c s)
+                      (declare (ignore c s))
+                      kv))
+(define-rule key-value-pairs (:or #'key-value-continuation
+                                  #'key-value))
+(define-rule filled-object (:and (:char #\{)
+                                 (:many #'key-value-pairs)
+                                 (:char #\}))
+             :apply (lambda (a kvs b)
+                      (declare (ignore a b))
+                      `(:object ,kvs)))
+(define-rule empty-object (:and (:char #\{)
+                                (:maybe #'spaces)
+                                (:char #\}))
+             :apply (lambda (a b c)
+                      (declare (ignore a b c))
+                      `(:object)))
+(define-rule object-literal (:or #'empty-object
+                                 #'filled-object))
 
 ;; array
 
-(:= empty-array (:and (:char #\[)
-                      (:maybe #'spaces)
-                      (:char #\]))
-    :call (lambda (x)
-            (declare (ignore x))
-            '(:array)))
-(:= array-item (:and (:maybe #'spaces)
-                     (:many #'literals)
-                     (:maybe #'spaces))
-    :apply (lambda (s value ss)
-             (declare (ignore s ss))
-             value))
-(:= array-continuation (:and #'array-item
-                             (:char #\,)
-                             (:maybe #'spaces))
-    :apply (lambda (value c s)
-             (declare (ignore c s))
-             value))
-(:= array-values (:or #'array-continuation
-                      #'array-item))
-(:= filled-array (:and (:char #\[)
-                       (:many #'array-values)
-                       (:char #\]))
-    :apply (lambda (a values b)
-             (declare (ignore a b))
-             `(:array ,values)))
-(:= array-literal (:or #'empty-array
-                       #'filled-array))
+(define-rule empty-array (:and (:char #\[)
+                               (:maybe #'spaces)
+                               (:char #\]))
+             :call (lambda (x)
+                     (declare (ignore x))
+                     '(:array)))
+(define-rule array-item (:and (:maybe #'spaces)
+                              (:many #'literals)
+                              (:maybe #'spaces))
+             :apply (lambda (s value ss)
+                      (declare (ignore s ss))
+                      value))
+(define-rule array-continuation (:and #'array-item
+                                      (:char #\,)
+                                      (:maybe #'spaces))
+             :apply (lambda (value c s)
+                      (declare (ignore c s))
+                      value))
+(define-rule array-values (:or #'array-continuation
+                               #'array-item))
+(define-rule filled-array (:and (:char #\[)
+                                (:many #'array-values)
+                                (:char #\]))
+             :apply (lambda (a values b)
+                      (declare (ignore a b))
+                      `(:array ,values)))
+(define-rule array-literal (:or #'empty-array
+                                #'filled-array))
 
-(:= boolean-literal (:or (:string "true")
-                         (:string "false"))
-    :call (lambda (value)
-  (cons :boolean (stringify value))))
+(define-grammar json
+  boolean-literal := (:or (:string "true")
+                          (:string "false")) :call (lambda (value)
+                          (cons :boolean (stringify value)))
 
-(:= null-literal (:string "null")
-    :call (lambda (x)
-            (declare (ignore x))
-            :null))
+  null-literal := (:string "null") :tag :null
 
-(:= literals (:or #'array-literal
-                  #'object-literal
-                  #'string-literal
-                  #'number-literal
-                  #'boolean-literal
-                  #'null-literal))
+  json := (:or #'array-literal
+               #'object-literal
+               #'string-literal
+               #'number-literal
+               #'boolean-literal
+               #'null-literal))
 
 (format t
         "~%~%Parsing a simple json file:~%~%~a~%"

--- a/tests.lisp
+++ b/tests.lisp
@@ -1,5 +1,7 @@
 (defpackage #:cl-bnf-tests
-  (:use #:cl #:fiveam #:cl-bnf))
+  (:use #:cl #:fiveam #:cl-bnf)
+  (:import-from #:cl-bnf
+                #:define-rule))
 
 (in-package :cl-bnf-tests)
 
@@ -7,55 +9,55 @@
     :description "Suite for tests which should fail.")
 
 (defun stringify (vs)
-  (if vs
-    (case (type-of vs)
-     (standard-char (string vs))
-     (t (reduce (lambda (acc x)
-                  (concatenate 'string acc
-                               (if x
-                                   (case (type-of x)
-                                     (standard-char (string x))
-                                     (list (stringify x))
-                                     (cons (stringify x)))
-                                   ""))) vs :initial-value "")))
-    ""))
+    (if vs
+        (case (type-of vs)
+          (standard-char (string vs))
+          (t (reduce (lambda (acc x)
+                       (concatenate 'string acc
+                                    (if x
+                                        (case (type-of x)
+                                          (standard-char (string x))
+                                          (list (stringify x))
+                                          (cons (stringify x)))
+                                        ""))) vs :initial-value "")))
+        ""))
 
 (defun numeric-char-p (char)
-  (and (char-not-lessp char #\0)
-       (char-not-greaterp char #\9)))
+    (and (char-not-lessp char #\0)
+         (char-not-greaterp char #\9)))
 
-(:= single-character (:char #\a))
-(:= one-character (:one #'alpha-char-p))
-(:= many-a (:many (:char #\a)))
-(:= wording (:many #'single-character))
-(:= ident-or-num (:or (:one #'alpha-char-p)
-                      (:one #'numeric-char-p)))
-(:= letter-num (:and (:one #'alpha-char-p)
-                     (:one #'numeric-char-p)))
+(define-rule single-character (:char #\a))
+(define-rule one-character (:one #'alpha-char-p))
+(define-rule many-a (:many (:char #\a)))
+(define-rule wording (:many #'single-character))
+(define-rule ident-or-num (:or (:one #'alpha-char-p)
+                               (:one #'numeric-char-p)))
+(define-rule letter-num (:and (:one #'alpha-char-p)
+                              (:one #'numeric-char-p)))
 
-(:= identifier (:many #'single-character)
-    :call (lambda (x)
-            (cons :identifier (stringify x))))
+(define-rule identifier (:many #'single-character)
+             :call (lambda (x)
+                     (cons :identifier (stringify x))))
 
-(:= abc (:string "abc"))
-(:= repeat-abc (:many #'abc))
+(define-rule abc (:string "abc"))
+(define-rule repeat-abc (:many #'abc))
 
-(:= repeat-abc2 (:many (:or (:and #'abc
-                                  (:many (:char #\space)))
-                            #'abc)))
+(define-rule repeat-abc2 (:many (:or (:and #'abc
+                                           (:many (:char #\space)))
+                                     #'abc)))
 
-(:= spaces (:many (:char #\space)))
+(define-rule spaces (:many (:char #\space)))
 
-(:= number-literal (:many (:one #'numeric-char-p))
-    :call (lambda (value) (cons :number (stringify value))))
-(:= assignment (:and #'identifier
-                     (:maybe #'spaces)
-                     (:char #\=)
-                     (:maybe #'spaces)
-                     #'number-literal)
-    :apply (lambda (lhs sp e sp2 expr)
-             (declare (ignore e sp sp2))
-             `(:assignment ,lhs ,expr)))
+(define-rule number-literal (:many (:one #'numeric-char-p))
+             :call (lambda (value) (cons :number (stringify value))))
+(define-rule assignment (:and #'identifier
+                              (:maybe #'spaces)
+                              (:char #\=)
+                              (:maybe #'spaces)
+                              #'number-literal)
+             :apply (lambda (lhs sp e sp2 expr)
+                      (declare (ignore e sp sp2))
+                      `(:assignment ,lhs ,expr)))
 
 (5am:def-test test-single-char (:suite test-suite)
   (5am:is (char-equal (parse #'single-character "a") #\a)))


### PR DESCRIPTION
now we can write grammar that woud be more like on the text books.

the `:=` is now deprecated since it was incorrectly used,
exported or whatever. instead, we can use `define-rule`
for simple rules.


```lisp
(define-rule boolean-literal (:or (:string "true")
                                 (:string "false")) :call (lambda (value)
                                                          (cons :boolean (stringify value)))

(define-grammar boolean-or-nothing
  null-literal := (:string "null") :tag :null

  literal := (:or #'boolean-literal #'null-literal))

(parse #'literals "null")

=> :null
```

closes #6.